### PR TITLE
Fix Vertcoin capitalisation

### DIFF
--- a/cryptocurrencies.json
+++ b/cryptocurrencies.json
@@ -2056,7 +2056,7 @@
   "VRM": "Verium",
   "VRS": "Veros",
   "VERSA": "Versa Token",
-  "VTC": "VertCoin",
+  "VTC": "Vertcoin",
   "VTX": "Vertex",
   "VST": "Vestarin",
   "VZT": "Vezt",


### PR DESCRIPTION
It's a lowercase "c": https://vertcoin.org/